### PR TITLE
Invalid path for multi-root workspace

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [8, 10, 12]
+        node: [10, 12]
 
     steps:
       - name: Clone repository

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "vnu-jar": "19.9.4"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "files": [
     "dist/{css,js}/*.{css,js,map}",


### PR DESCRIPTION
By the time v5 stable will be out, 8 will be EOL (December 2019).