### PR TITLE
Create a new pull request

### DIFF
--- a/build/generate-sri.js
+++ b/build/generate-sri.js
@@ -55,6 +55,6 @@ files.forEach(file => {
 
     console.log(`${file.configPropertyName}: ${integrity}`)
 
-    sh.sed('-i', new RegExp(`(\\s${file.configPropertyName}:\\s+"|')(\\S+)("|')`), `$1${integrity}$3`, configFile)
+    sh.sed('-i', new RegExp(`^(\\s+${file.configPropertyName}:\\s+["'])\\S*(["'])`), `$1${integrity}$2`, configFile)
   })
 })


### PR DESCRIPTION
When using single-quotes in config.yml, the previous
regular expression in build/generate-cli.js wasn't working correctly,
it was replacing ALL string values with hashes.
Now both double- and single-quotes can be used in config.yml,
and the RegExp will work as expected.

Also, allow trailing whitespaces and empty ("") values to be matched.

Co-authored-by: XhmikosR <xhmikosr@gmail.com>